### PR TITLE
Fix store and load of checkpoint for FastMonodomainSolver

### DIFF
--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_base.h
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_base.h
@@ -117,9 +117,11 @@ public:
   //! get a reference to the nested solvers
   NestedSolversType &nestedSolvers();
 
-  void loadFiberData();
+  //! save the current state of the locally computed fibers in a checkpoint variable, to be later restored by restoreFiberDataCheckpoint()
+  void saveFiberDataCheckpoint();
 
-  void saveFiberData();
+  //! restore the checkpoint created by saveFiberDataCheckpoint() and set the local fiber's state to the saved state in the checkpoint
+  void restoreFiberDataCheckpoint();
 
   /** data to be exchanged for computation of a single fiber
    *  The data stored herein is used for local computation.
@@ -213,6 +215,7 @@ protected:
   NestedSolversType nestedSolvers_;   //< the nested solvers object that would normally solve the problem
 
   std::vector<FiberPointBuffers<nStates>> fiberPointBuffers_;    //< computation buffers for the 0D problem, the states vector used when optimizationType == "vc"
+  std::vector<FiberPointBuffers<nStates>> fiberPointBuffersLastCheckpoint_;    //< copy of fiberPointBuffers_ that was stored at the last checkpoint, needed for implicit coupling with precice, where a previous state needs to be restored
 
   std::string fiberDistributionFilename_;  //< filename of the fiberDistributionFile, which contains motor unit numbers for fiber numbers
   std::string firingTimesFilename_;        //< filename of the firingTimesFile, which contains points in time of stimulation for each motor unit
@@ -225,7 +228,6 @@ protected:
   OutputWriter::Manager outputWriterManager_;     //< manager object holding all output writers
 
   std::vector<FiberData> fiberData_;  //< vector of fibers, the number of entries is the number of fibers to be computed by the own rank (nFibersToCompute_)
-  std::vector<FiberData> fiberDataOld_; 
   int nFibersToCompute_;              //< number of fibers where own rank is involved (>= n.fibers that are computed by own rank)
   int nInstancesToCompute_;           //< number of instances of the Hodgkin-Huxley (or other CellML) problem to compute on this rank
   int nInstancesToComputePerFiber_;   //< number of instances to compute per fiber, i.e., global number of instances of a fiber

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_communication.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_communication.tpp
@@ -498,17 +498,17 @@ updateFiberData()
 
 template<int nStates, int nAlgebraics, typename DiffusionTimeSteppingScheme>
 void FastMonodomainSolverBase<nStates,nAlgebraics,DiffusionTimeSteppingScheme>::
-loadFiberData(){
+restoreFiberDataCheckpoint()
+{
   LOG(INFO) << "in loadFiberData";
   LOG(INFO) << "vm values" << fiberData_[0].vmValues;
-  fiberData_ = fiberDataOld_;
-  LOG(INFO) << "new vm values" << fiberData_[0].vmValues;
+  fiberPointBuffers_ = fiberPointBuffersLastCheckpoint_;
 
 }
 
 template<int nStates, int nAlgebraics, typename DiffusionTimeSteppingScheme>
 void FastMonodomainSolverBase<nStates,nAlgebraics,DiffusionTimeSteppingScheme>::
-saveFiberData(){
-
-  fiberDataOld_ = fiberData_;
+saveFiberDataCheckpoint()
+{
+  fiberPointBuffersLastCheckpoint_ = fiberPointBuffers_;
 }

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_compute.tpp
@@ -102,8 +102,9 @@ computeMonodomain(bool withOutputWritersEnabled)
   for (int timeStepNo = 0; timeStepNo < nTimeStepsSplitting_; timeStepNo++)
   {
 
-    if (timeStepNo>0){
-      loadFiberData();
+    if (timeStepNo > 0)
+    {
+      restoreFiberDataCheckpoint();
       //fetchFiberData();
       LOG(INFO) << "load fiber data ";
     }
@@ -125,9 +126,10 @@ computeMonodomain(bool withOutputWritersEnabled)
 
     updateFiberData();
 
-    if (timeStepNo < nTimeStepsSplitting_/2){
+    if (timeStepNo < nTimeStepsSplitting_/2)
+    {
       // fakeTimeStepNo += 1;
-      saveFiberData();
+      saveFiberDataCheckpoint();
       LOG(INFO) << "save fiber data";
     }
 

--- a/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_initialization.tpp
+++ b/core/src/specialized_solver/fast_monodomain_solver/fast_monodomain_solver_initialization.tpp
@@ -492,9 +492,6 @@ initializeDataStructures()
     << " Vc vectors, size of double_v: " << Vc::double_v::size() << ", "
     << statesForTransferIndices_.size()-1 << " additional states for transfer, "
     << algebraicsForTransferIndices_.size() << " algebraics for transfer";
-
-  fiberDataOld_ = fiberData_;
-
 }
 
 template<int nStates, int nAlgebraics, typename DiffusionTimeSteppingScheme>


### PR DESCRIPTION
In #9, it was tried to store and reload a checkpoint of the current fiber status, but the wrong variable was used. This PR fixes the intended functionality and adds the previously missing comments in the header file.