### PR TITLE
Added link test for easylogging++ library.

### DIFF
--- a/.github/workflows/ci_cmake_ubuntu2204.yml
+++ b/.github/workflows/ci_cmake_ubuntu2204.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
          sudo apt-get update -yq
          sudo apt-get install -yq --no-install-recommends libmpich-dev mpich
+         sudo apt-get install libxml2-dev
          sudo apt update
          sudo apt install software-properties-common
          sudo add-apt-repository ppa:deadsnakes/ppa

--- a/.github/workflows/ci_cmake_ubuntu2204.yml
+++ b/.github/workflows/ci_cmake_ubuntu2204.yml
@@ -30,6 +30,7 @@ jobs:
          sudo apt install python3-numpy
          sudo apt install libeigen3-dev
          sudo apt install libboost-filesystem-dev libboost-log-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev libboost-test-dev
+         sudo apt install libeasyloggingpp-dev
     
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/ci_cmake_ubuntu2204.yml
+++ b/.github/workflows/ci_cmake_ubuntu2204.yml
@@ -21,6 +21,7 @@ jobs:
          sudo apt-get update -yq
          sudo apt-get install -yq --no-install-recommends libmpich-dev mpich
          sudo apt-get install libxml2-dev
+         sudo apt-get install zlib1g-dev
          sudo apt update
          sudo apt install software-properties-common
          sudo add-apt-repository ppa:deadsnakes/ppa

--- a/cmake/FindEASYLOGGINGPP.cmake
+++ b/cmake/FindEASYLOGGINGPP.cmake
@@ -1,0 +1,14 @@
+
+find_package(PkgConfig QUIET)
+
+pkg_check_modules(EASYLOGGINGPP REQUIRED easyloggingpp)
+
+find_path(ELPP_INCLUDE_DIRS NAMES easylogging++.h)
+
+add_library(
+  elpp SHARED
+  ${ELPP_INCLUDE_DIRS}/easylogging++.h
+  ${ELPP_INCLUDE_DIRS}/easylogging++.cc
+)
+
+set(EASYLOGGINGPP_LIBRARIES "elpp")

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -2,6 +2,9 @@
 # Check for MPI installation.
 find_package(MPI COMPONENTS C CXX REQUIRED)
 
+# Check for zlib installation
+find_package(ZLIB REQUIRED)
+
 # Check for Python3
 find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
 
@@ -20,4 +23,5 @@ find_package(LibXml2 REQUIRED)
 include_directories(${MPI_CXX_INCLUDE_DIRS}
                     ${Python3_INCLUDE_DIRS}
                     ${LIBXML2_INCLUDE_DIR}
+                    ${ZLIB_INCLUDE_DIRS}
                    )

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -20,6 +20,9 @@ find_package(Boost REQUIRED COMPONENTS log log_setup thread system filesystem pr
 # Check for libxml2
 find_package(LibXml2 REQUIRED)
 
+# Check for easylogging++
+include(cmake/FindEASYLOGGINGPP.cmake)
+
 include_directories(${MPI_CXX_INCLUDE_DIRS}
                     ${Python3_INCLUDE_DIRS}
                     ${LIBXML2_INCLUDE_DIR}

--- a/cmake/find_dependencies.cmake
+++ b/cmake/find_dependencies.cmake
@@ -14,6 +14,10 @@ endif()
 # Check for libboost
 find_package(Boost REQUIRED COMPONENTS log log_setup thread system filesystem program_options unit_test_framework)
 
+# Check for libxml2
+find_package(LibXml2 REQUIRED)
+
 include_directories(${MPI_CXX_INCLUDE_DIRS}
                     ${Python3_INCLUDE_DIRS}
+                    ${LIBXML2_INCLUDE_DIR}
                    )

--- a/testing/link_test/CMakeLists.txt
+++ b/testing/link_test/CMakeLists.txt
@@ -33,3 +33,8 @@ add_test(NAME test_boost_unit_test_framework COMMAND test_boost_unit_test_framew
 add_executable(test_xml2 test_xml2.cpp)
 target_link_libraries(test_xml2 ${LIBXML2_LIBRARIES})
 add_test(NAME test_xml2 COMMAND test_xml2)
+
+# Test for easyloggingpp installation.
+add_executable(test_easyloggingpp test_easyloggingpp.cpp)
+target_link_libraries(test_easyloggingpp ${EASYLOGGINGPP_LIBRARIES})
+add_test(NAME test_easyloggingpp COMMAND test_easyloggingpp)

--- a/testing/link_test/CMakeLists.txt
+++ b/testing/link_test/CMakeLists.txt
@@ -23,3 +23,8 @@ add_test(NAME test_boost COMMAND test_boost)
 add_executable(test_boost_unit_test_framework test_boost_unit_test_framework.cpp)
 target_link_libraries(test_boost_unit_test_framework ${Boost_LIBRARIES})
 add_test(NAME test_boost_unit_test_framework COMMAND test_boost_unit_test_framework)
+
+# Test for Boost installation.
+add_executable(test_xml2 test_xml2.cpp)
+target_link_libraries(test_xml2 ${LIBXML2_LIBRARIES})
+add_test(NAME test_xml2 COMMAND test_xml2)

--- a/testing/link_test/CMakeLists.txt
+++ b/testing/link_test/CMakeLists.txt
@@ -4,6 +4,11 @@ add_executable(test_mpi test_mpi.cpp)
 target_link_libraries(test_mpi ${MPI_CXX_LIBRARIES})
 add_test(NAME test_mpi COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 test_mpi)
 
+# Test for zlib installation.
+add_executable(test_zlib test_zlib.cpp)
+target_link_libraries(test_zlib ${ZLIB_LIBRARIES})
+add_test(NAME test_zlib COMMAND test_zlib)
+
 # Test for Python3 installation.
 add_executable(test_python test_python.cpp)
 target_link_libraries(test_python ${Python3_LIBRARIES})

--- a/testing/link_test/test_easyloggingpp.cpp
+++ b/testing/link_test/test_easyloggingpp.cpp
@@ -1,0 +1,9 @@
+
+#include <easylogging++.h>
+
+INITIALIZE_EASYLOGGINGPP
+
+int main(int argc, char* argv[]) {
+   LOG(INFO) << "My first info log using default logger";
+   return 0;
+}

--- a/testing/link_test/test_xml2.cpp
+++ b/testing/link_test/test_xml2.cpp
@@ -1,0 +1,14 @@
+
+#include <libxml/xmlwriter.h>
+#include <cassert>
+#include <iostream>
+
+int main()
+{
+  xmlTextWriterPtr writer;
+  writer = xmlNewTextWriterFilename("xml_output.tmp", 0);
+  assert(writer != NULL);
+  std::cout << "xml writer success." << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/testing/link_test/test_zlib.cpp
+++ b/testing/link_test/test_zlib.cpp
@@ -1,0 +1,12 @@
+
+#include <zlib.h>
+#include <iostream>
+
+int main()
+{
+  z_off_t len = 3000;
+  uLong a = 1, b = 2;
+  if (a == adler32_combine (a, b, len)) {;}
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The library does not generate any shared object or static object. For that reason a shared object is created manually and placed in the build folder. In CMake it is always more convenient to work with targets rather than files. 