### PR TITLE
Write average traction to precice

### DIFF
--- a/core/src/control/precice/surface_coupling/01_initialize.h
+++ b/core/src/control/precice/surface_coupling/01_initialize.h
@@ -55,14 +55,12 @@ protected:
     std::string displacementsName;            //< precice name of the displacements variable, if any
     std::string velocitiesName;               //< precice name of the velocities variable, if any
     std::string tractionName;                 //< precice name of the traction variable, if any
-    std::string averagedTractionName;         //< precice name of the z-averaged traction variable, if any
-
 
     int preciceDataIdDisplacements;           //< precice id of the displacements variable
     int preciceDataIdVelocities;              //< precice id of the velocities variable
     int preciceDataIdTraction;                //< precice id of the traction variable
-    int preciceDataIdAveragedTraction;        //< precice id of the z-averaged traction variable
 
+    bool average;
 
     enum {
       ioRead,

--- a/core/src/control/precice/surface_coupling/01_initialize.h
+++ b/core/src/control/precice/surface_coupling/01_initialize.h
@@ -55,10 +55,14 @@ protected:
     std::string displacementsName;            //< precice name of the displacements variable, if any
     std::string velocitiesName;               //< precice name of the velocities variable, if any
     std::string tractionName;                 //< precice name of the traction variable, if any
+    std::string averagedTractionName;         //< precice name of the z-averaged traction variable, if any
+
 
     int preciceDataIdDisplacements;           //< precice id of the displacements variable
     int preciceDataIdVelocities;              //< precice id of the velocities variable
     int preciceDataIdTraction;                //< precice id of the traction variable
+    int preciceDataIdAveragedTraction;        //< precice id of the z-averaged traction variable
+
 
     enum {
       ioRead,

--- a/core/src/control/precice/surface_coupling/01_initialize.tpp
+++ b/core/src/control/precice/surface_coupling/01_initialize.tpp
@@ -309,13 +309,15 @@ initializePreciceData()
     else if (mode == "write-averaged-traction")
     {
       preciceData.ioType = PreciceData::ioWrite;
+      preciceData.average = true;
+      LOG(INFO) << "Set average = true";
 
       // get precice names of the variables
-      preciceData.averagedTractionName = currentPreciceData.getOptionString("averagedTractionName", "averagedTraction");
+      preciceData.tractionName = currentPreciceData.getOptionString("tractionName", "Traction");
 
       // get precice data ids
-      preciceData.preciceDataIdAveragedTraction = preciceSolverInterface_->getDataID(
-      preciceData.averagedTractionName, preciceData.preciceMesh->preciceMeshId);
+      preciceData.preciceDataIdTraction = preciceSolverInterface_->getDataID(
+      preciceData.tractionName, preciceData.preciceMesh->preciceMeshId);
     }
     else
     {

--- a/core/src/control/precice/surface_coupling/01_initialize.tpp
+++ b/core/src/control/precice/surface_coupling/01_initialize.tpp
@@ -280,18 +280,6 @@ initializePreciceData()
       preciceData.preciceDataIdTraction = preciceSolverInterface_->getDataID(
         preciceData.tractionName, preciceData.preciceMesh->preciceMeshId);
     }
-    else if (mode == "read-averaged-traction")
-    {
-      preciceData.ioType = PreciceData::ioRead;
-      preciceData.boundaryConditionType = PreciceData::bcTypeNeumann;
-
-      // get precice names of the variables
-      preciceData.averagedTractionName = currentPreciceData.getOptionString("averagedTractionName", "averagedTraction");
-
-      // get precice data ids
-      preciceData.preciceDataIdAveragedTraction = preciceSolverInterface_->getDataID(
-      preciceData.averagedTractionName, preciceData.preciceMesh->preciceMeshId);
-    }
     else if (mode == "write-displacements-velocities")
     {
       preciceData.ioType = PreciceData::ioWrite;
@@ -332,7 +320,7 @@ initializePreciceData()
     else
     {
       LOG(FATAL) << currentPreciceData << "[\"mode\"] is \"" << mode << "\", "
-        << "possible values are: \"read-displacements-velocities\", \"read-traction\", \"read-averaged-traction\", \"write-displacements-velocities\", \"write-traction\", \"write-averaged-traction\".";
+        << "possible values are: \"read-displacements-velocities\", \"read-traction\", \"write-displacements-velocities\", \"write-traction\", \"write-averaged-traction\".";
     }
 
     // store preciceData to vector

--- a/core/src/control/precice/surface_coupling/01_initialize.tpp
+++ b/core/src/control/precice/surface_coupling/01_initialize.tpp
@@ -280,6 +280,18 @@ initializePreciceData()
       preciceData.preciceDataIdTraction = preciceSolverInterface_->getDataID(
         preciceData.tractionName, preciceData.preciceMesh->preciceMeshId);
     }
+    else if (mode == "read-averaged-traction")
+    {
+      preciceData.ioType = PreciceData::ioRead;
+      preciceData.boundaryConditionType = PreciceData::bcTypeNeumann;
+
+      // get precice names of the variables
+      preciceData.averagedTractionName = currentPreciceData.getOptionString("averagedTractionName", "averagedTraction");
+
+      // get precice data ids
+      preciceData.preciceDataIdAveragedTraction = preciceSolverInterface_->getDataID(
+      preciceData.averagedTractionName, preciceData.preciceMesh->preciceMeshId);
+    }
     else if (mode == "write-displacements-velocities")
     {
       preciceData.ioType = PreciceData::ioWrite;
@@ -306,10 +318,21 @@ initializePreciceData()
       preciceData.preciceDataIdTraction = preciceSolverInterface_->getDataID(
         preciceData.tractionName, preciceData.preciceMesh->preciceMeshId);
     }
+    else if (mode == "write-averaged-traction")
+    {
+      preciceData.ioType = PreciceData::ioWrite;
+
+      // get precice names of the variables
+      preciceData.averagedTractionName = currentPreciceData.getOptionString("averagedTractionName", "averagedTraction");
+
+      // get precice data ids
+      preciceData.preciceDataIdAveragedTraction = preciceSolverInterface_->getDataID(
+      preciceData.averagedTractionName, preciceData.preciceMesh->preciceMeshId);
+    }
     else
     {
       LOG(FATAL) << currentPreciceData << "[\"mode\"] is \"" << mode << "\", "
-        << "possible values are: \"read-displacements-velocities\", \"read-traction\", \"write-displacements-velocities\", \"write-traction\".";
+        << "possible values are: \"read-displacements-velocities\", \"read-traction\", \"read-averaged-traction\", \"write-displacements-velocities\", \"write-traction\", \"write-averaged-traction\".";
     }
 
     // store preciceData to vector

--- a/core/src/control/precice/surface_coupling/02_read_write.h
+++ b/core/src/control/precice/surface_coupling/02_read_write.h
@@ -43,7 +43,7 @@ protected:
   std::vector<Vec3> displacementVectors_;           //< send value buffer for the displacement values
   std::vector<Vec3> velocityVectors_;              //< send value buffer for the velocity values
   std::vector<Vec3> tractionVectors_;                //< send value buffer for the traction values
-  std::vector<Vec3> averageTractionVectors_;                //< send value buffer for the averaged z-tractio values
+  std::vector<Vec3> averagedTractionVectors_;                //< send value buffer for the averaged z-tractio values
 
 };
 

--- a/core/src/control/precice/surface_coupling/02_read_write.h
+++ b/core/src/control/precice/surface_coupling/02_read_write.h
@@ -39,9 +39,11 @@ protected:
   std::vector<double> displacementValues_;   //< read value buffer for the displacement values
   std::vector<double> velocityValues_;      //< read value buffer for the velocity values
   std::vector<double> tractionValues_;        //< read value buffer for the traction values
+  std::vector<double> averagedtractionValues_;        //< read value buffer for the averaged z-traction values
   std::vector<Vec3> displacementVectors_;           //< send value buffer for the displacement values
   std::vector<Vec3> velocityVectors_;              //< send value buffer for the velocity values
   std::vector<Vec3> tractionVectors_;                //< send value buffer for the traction values
+  std::vector<Vec3> averageTractionVectors_;                //< send value buffer for the averaged z-tractio values
 
 };
 

--- a/core/src/control/precice/surface_coupling/02_read_write.h
+++ b/core/src/control/precice/surface_coupling/02_read_write.h
@@ -39,11 +39,9 @@ protected:
   std::vector<double> displacementValues_;   //< read value buffer for the displacement values
   std::vector<double> velocityValues_;      //< read value buffer for the velocity values
   std::vector<double> tractionValues_;        //< read value buffer for the traction values
-  std::vector<double> averagedtractionValues_;        //< read value buffer for the averaged z-traction values
   std::vector<Vec3> displacementVectors_;           //< send value buffer for the displacement values
   std::vector<Vec3> velocityVectors_;              //< send value buffer for the velocity values
   std::vector<Vec3> tractionVectors_;                //< send value buffer for the traction values
-  std::vector<Vec3> averagedTractionVectors_;                //< send value buffer for the averaged z-tractio values
 
 };
 

--- a/core/src/control/precice/surface_coupling/02_read_write.tpp
+++ b/core/src/control/precice/surface_coupling/02_read_write.tpp
@@ -331,13 +331,11 @@ preciceWriteData()
         this->getTractionValues(this->nestedSolver_, preciceData.preciceMesh->dofNosLocal, tractionValues_);
         // average z-values of traction
         double average_traction = 0.0;
-        int size_traction = 0;
         for (int i = 2; i < tractionValues_.size(); i+=3)
         {
           average_traction += tractionValues_[i];
-          size_traction += 1;
         }
-        average_traction /= size_traction;
+        average_traction /= (tractionValues_.size()/3);
         for (int i = 2; i < tractionValues_.size(); i+=3)
         {
           tractionValues_[i] = average_traction;

--- a/examples/electrophysiology/neuromuscular/ami/plot_ami.py
+++ b/examples/electrophysiology/neuromuscular/ami/plot_ami.py
@@ -1,0 +1,39 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+with open('build_release/defaulttendon.txt', 'r') as f:
+    lines = f.readlines()
+    tendont = [float(line.split()[0]) for line in lines]
+    tendons = [float(line.split()[1]) for line in lines]
+    tendone = [float(line.split()[2]) for line in lines]
+
+with open('build_release/defaultmuscle_left.txt', 'r') as f:
+    lines = f.readlines()
+    leftt = [float(line.split()[0]) for line in lines]
+    lefts = [float(line.split()[1]) for line in lines]
+    lefte = [float(line.split()[2]) for line in lines]
+
+with open('build_release/defaultmuscle_right.txt', 'r') as f:
+    lines = f.readlines()
+    rightt = [float(line.split()[0]) for line in lines]
+    rights = [float(line.split()[1]) for line in lines]
+    righte = [float(line.split()[2]) for line in lines]
+
+
+# paper: markersize: 0.8, font.size: 18
+
+plt.rcParams.update({'font.size': 16})
+linewidthh = 1.5
+
+plt.figure().set_figheight(6)
+plt.plot(leftt,np.array(lefte) - np.array(lefts)-15.0,linewidth=linewidthh,label="Muscle 1")
+plt.plot(rightt,np.array(righte) - np.array(rights)-15.0, linewidth=linewidthh,label="Muscle 2")
+plt.plot(tendont,np.array(tendone) - np.array(tendons)-5.0, linewidth=linewidthh,label="Tendon")
+plt.xlabel("Time (ms)")
+plt.ylabel("Change in length (cm)")
+plt.title("No average - 0.0")
+plt.legend()
+plt.show()
+
+

--- a/examples/electrophysiology/neuromuscular/ami/precice_config_bi.xml
+++ b/examples/electrophysiology/neuromuscular/ami/precice_config_bi.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0"?>
+
+<precice-configuration>
+  <!-- format for console output of precice -->
+  <log>
+    <sink type="stream" output="stdout"  filter='(%Severity% >= debug) and (not (%Function% = "advance"))' format="\033[0;33m%Rank% [precice]\033[0m %ColorizedSeverity%\033[0;33m%Message%\033[0m" enabled="true" />
+  </log>
+
+  <solver-interface dimensions="3">
+    <data:vector name="Velocity"/>
+    <data:vector name="Displacement"/>
+    <data:vector name="Traction"/>
+
+
+    <mesh name="TendonMeshLeft">
+       <use-data name="Displacement"/>
+       <use-data name="Velocity"/>
+       <use-data name="Traction"/>
+    </mesh>
+
+    <mesh name="TendonMeshRight">
+       <use-data name="Displacement"/>
+       <use-data name="Velocity"/>
+       <use-data name="Traction"/>
+    </mesh>
+
+    <mesh name="MuscleMeshLeft">
+       <use-data name="Displacement"/>
+       <use-data name="Velocity"/>
+       <use-data name="Traction"/>
+    </mesh>
+
+    <mesh name="MuscleMeshRight">
+       <use-data name="Displacement"/>
+       <use-data name="Velocity"/>
+       <use-data name="Traction"/>
+    </mesh>
+
+
+    <participant name="TendonSolver"> 
+      <use-mesh name="TendonMeshLeft" provide="yes"/>
+      <use-mesh name="TendonMeshRight" provide="yes"/>
+      <use-mesh name="MuscleMeshLeft" from="MuscleSolverLeft"/>
+      <use-mesh name="MuscleMeshRight" from="MuscleSolverRight"/>
+
+      <read-data name="Displacement"  mesh="TendonMeshRight"/>
+      <read-data name="Velocity"  mesh="TendonMeshRight"/>
+      <write-data  name="Traction"      mesh="TendonMeshRight"/>
+
+      <write-data name="Displacement"  mesh="TendonMeshLeft"/>
+      <write-data name="Velocity"  mesh="TendonMeshLeft"/>
+      <read-data  name="Traction"      mesh="TendonMeshLeft"/>
+
+      <mapping:nearest-neighbor direction="read" from="MuscleMeshLeft" to="TendonMeshLeft" constraint="consistent"/>
+      <mapping:nearest-neighbor direction="read" from="MuscleMeshRight" to="TendonMeshRight" constraint="consistent"/>
+
+      <export:vtk directory="preCICE-output" />
+    </participant>
+
+    <participant name="MuscleSolverLeft">
+      <use-mesh name="MuscleMeshLeft"  provide="yes"/>
+      <use-mesh name="TendonMeshLeft"     from="TendonSolver"/>
+
+      <read-data  name="Displacement"  mesh="MuscleMeshLeft"/>
+      <read-data  name="Velocity"  mesh="MuscleMeshLeft"/>
+      <write-data name="Traction"      mesh="MuscleMeshLeft"/>
+
+      <mapping:nearest-neighbor direction="read" from="TendonMeshLeft" to="MuscleMeshLeft" constraint="consistent"/>
+      <export:vtk directory="preCICE-output"/>
+    </participant>
+    
+    <participant name="MuscleSolverRight">
+      <use-mesh name="MuscleMeshRight"  provide="yes"/>
+      <use-mesh name="TendonMeshRight"     from="TendonSolver"/>
+
+      <write-data  name="Displacement"  mesh="MuscleMeshRight"/>
+      <write-data  name="Velocity"  mesh="MuscleMeshRight"/>
+      <read-data name="Traction"      mesh="MuscleMeshRight"/>
+      
+      <mapping:nearest-neighbor direction="read" from="TendonMeshRight" to="MuscleMeshRight" constraint="consistent"/>
+      <export:vtk directory="preCICE-output"/>
+    </participant>
+
+    <!-- Communication method, use TCP sockets, Change network to "ib0" on SuperMUC -->
+    <m2n:sockets from="TendonSolver" to="MuscleSolverLeft" network="lo" />
+    <m2n:sockets from="TendonSolver" to="MuscleSolverRight" network="lo" />
+
+    <coupling-scheme:serial-explicit>
+      <participants first="MuscleSolverLeft" second="TendonSolver"/>
+      
+      <max-time value="20.0"/>          
+      <time-window-size value="0.01"/>  
+
+      <exchange data="Displacement" mesh="TendonMeshLeft" from="TendonSolver" to="MuscleSolverLeft"/>  
+      <exchange data="Velocity" mesh="TendonMeshLeft" from="TendonSolver" to="MuscleSolverLeft"/>  
+      <exchange data="Traction" mesh="MuscleMeshLeft" from="MuscleSolverLeft" to="TendonSolver"/>  
+    </coupling-scheme:serial-explicit>
+
+    <coupling-scheme:parallel-implicit>
+      <participants first="TendonSolver" second="MuscleSolverRight"/>
+            
+      <max-time value="20.0"/>          
+      <time-window-size value="0.01"/>  
+
+      <acceleration:IQN-ILS>
+        <data name="Displacement" mesh="MuscleMeshRight"/>
+        <data name="Velocity" mesh="MuscleMeshRight"/>
+        <data name="Traction" mesh="TendonMeshRight"/>
+        <preconditioner type="residual-sum"/>
+        <filter type="QR2" limit="1e-3"/>
+        <initial-relaxation value="0.1"/>
+        <max-used-iterations value="40"/>
+        <time-windows-reused value="15"/>
+      </acceleration:IQN-ILS>
+
+      <max-iterations value="25" />
+
+      <relative-convergence-measure limit="1e-3" data="Displacement" mesh="MuscleMeshRight" strict="0"/>
+      <relative-convergence-measure limit="1e-3" data="Velocity" mesh="MuscleMeshRight" strict="0"/>
+      <absolute-convergence-measure limit="1e-3" data="Traction" mesh="TendonMeshRight" strict="0"/>
+       
+      <exchange data="Displacement" mesh="MuscleMeshRight" from="MuscleSolverRight" to="TendonSolver"/>  
+      <exchange data="Velocity" mesh="MuscleMeshRight" from="MuscleSolverRight" to="TendonSolver"/>  
+      <exchange data="Traction" mesh="TendonMeshRight" from="TendonSolver" to="MuscleSolverRight"/> 
+    </coupling-scheme:parallel-implicit>
+
+  </solver-interface>
+</precice-configuration>

--- a/examples/electrophysiology/neuromuscular/ami/readme.md
+++ b/examples/electrophysiology/neuromuscular/ami/readme.md
@@ -1,13 +1,23 @@
 # AMI model
-A two-muscles-one-tendon model using OpenDiHu and preCICE
+
+## Setup
+A two-muscles-one-tendon AMI (Agonist-antagonist Myoneural Interface) model. Three OpenDiHu-based participants are coupled using preCICE: muscle 1 (left muscle), muscle 2 (right muscle) and the tendon. 
+
+Muscle 1's solver combines the fast monodomain solver with the Mooney-Rivlin non-linear continuum mechanics model. Muscle 1 is activated with the input file `"input/MU_firing_times_real.txt"`. The tendon and muscle 2 participants consist of a continuum mechanics solver alone, which assumes a Mooney-Rivlin non-linear muscle model and a hyper elastic non-linear tendon model respectively. When muscle 1 contracts, the tendon and muscle 2 deform accordingly.
+
+Surface coupling between the continuum mechanics solvers of the participants is applied. There are two interfaces where the mechanical coupling takes place: between muscle 1 and the tendon (muscle 1 sends traction to the tendon, which sends back displacement and velocity), and between the tendon and muscle 2 (the tendon sends traction to the muscle 2, which sends back displacement and velocity). Implicit coupling is needed, in particular when muscle 2 (soft material) sends traction to the tendon (stift material). We apply quasi-Newton acceleration using a residual-sum precondiioner.
+
+The default option for this case, uses preCICE's `multi-coupling` scheme to configure the coupling among the three participants. You can also select a composition of a `serial-explicit` scheme and a `parallel-implicit` scheme if in `variables.py` you set `precice_file = "../precice_config_bi.xml"`.
+
+
 
 ### How to build?
-Follow opendihu's documentation for installation, then run 
+Follow OpenDiHu's documentation for installation, then run 
 ```
 mkorn && sr
 ```
 ### How to run?
-You will need one terminal per each participant. All terminals should be at the same directory `ami/build_release`
+You will need one terminal per each participant. All terminals should be at the same directory, e.g., `ami/build_release`.
 
 terminal 1: left muscle
 ```
@@ -28,13 +38,13 @@ Alternatively you can use a tendon solver that assumes a linear material: Choose
 Here's an example on how to lunch the three participants in the cluster (Add this code to your bash file):
 ```
 echo "Launching left muscle"
-mpirun -n 1 ./muscle_precice ../settings_muscle_left.py &> left.log &
+mpirun -n 1 ./muscle ../settings_muscle_left.py &> left.log &
 
 echo "Launching tendon"
-mpirun -n 1 ./tendon_precice ../settings_tendon.py &> tendon.log &
+mpirun -n 1 ./tendon ../settings_tendon.py &> tendon.log &
 
 echo "Launching right muscle"
-mpirun -n 1 ./muscle_mechanics_precice ../settings_muscle_right.py &> right.log
+mpirun -n 1 ./only_mechanics_muscle ../settings_muscle_right.py &> right.log
 
 echo "Simulation completed."
 

--- a/examples/electrophysiology/neuromuscular/ami/settings_muscle_left.py
+++ b/examples/electrophysiology/neuromuscular/ami/settings_muscle_left.py
@@ -110,7 +110,7 @@ config = {
   "scenarioName":                   variables.scenario_name,    # scenario name which will appear in the log file
   "logFormat":                      "csv",                      # "csv" or "json", format of the lines in the log file, csv gives smaller files
   "solverStructureDiagramFile":     "solver_structure.txt",     # output file of a diagram that shows data connection between solvers
-  "mappingsBetweenMeshesLogFile":   "out/" + variables.scenario_name + "/mappings_between_meshes.txt",
+  "mappingsBetweenMeshesLogFile":   "out/" + variables.case_name + "/" + variables.scenario_name +"/mappings_between_meshes.txt",
   "meta": {                 # additional fields that will appear in the log
     "partitioning": [variables.n_subdomains_x, variables.n_subdomains_y, variables.n_subdomains_z]
   },

--- a/examples/electrophysiology/neuromuscular/ami/settings_muscle_right.py
+++ b/examples/electrophysiology/neuromuscular/ami/settings_muscle_right.py
@@ -208,7 +208,7 @@ config = {
       "initialValuesVelocities":     [[0.0,0.0,0.0] for _ in range(nx * ny * nz)],     # the initial values for the velocities, vector of values for every node [[node1-x,y,z], [node2-x,y,z], ...]
       "extrapolateInitialGuess":     True, 
 
-      "dirichletOutputFilename":     "out/"+variables.scenario_name+"/dirichlet_boundary_conditions_tendon",    # filename for a vtp file that contains the Dirichlet boundary condition nodes and their values, set to None to disable
+      "dirichletOutputFilename":     "out/" + variables.case_name + "/" + variables.scenario_name + "/dirichlet_boundary_conditions_tendon",    # filename for a vtp file that contains the Dirichlet boundary condition nodes and their values, set to None to disable
       # "totalForceLogFilename":       "out/tendon_force.csv",              # filename of a log file that will contain the total (bearing) forces and moments at the top and bottom of the volume
       # "totalForceLogOutputInterval": 10,                                  # output interval when to write the totalForceLog file
       # "totalForceBottomElementNosGlobal":  [j*nx + i for j in range(ny) for i in range(nx)],                  # global element nos of the bottom elements used to compute the total forces in the log file totalForceLogFilename

--- a/examples/electrophysiology/neuromuscular/ami/settings_tendon.py
+++ b/examples/electrophysiology/neuromuscular/ami/settings_tendon.py
@@ -145,7 +145,7 @@ config = {
 
         },
         {
-          "mode":                 "write-traction",                    # mode is one of "read-displacements-velocities", "read-traction", "write-displacements-velocities", "write-traction"
+          "mode":                 "write-averaged-traction",                    # mode is one of "read-displacements-velocities", "read-traction", "write-displacements-velocities", "write-traction"
           "preciceMeshName":      "TendonMeshRight",                    # name of the precice coupling surface mesh, as given in the precice xml settings 
           "tractionName":         "Traction",                         # name of the traction "data", i.e. field variable, as given in the precice xml settings file
         }


### PR DESCRIPTION
This branch provides the option to send averaged z-traction values.

 This means that additionally to the existing modes (`read-traction`, `read-displacements-velocities`, `write-traction`, `write-displacements-velocities`) another mode `write-averaged-traction` is possible. 

Note that only z-values are averaged. x-values and y-values are sent as usual.  The average is implemented by adding up all of the z-values in the coupled surface and dividing by the number of mesh points.  The averaged z-traction value overwrites the z-traction value in each point. Therefore, averaged traction values are read as usual by specifying `read-traction` in the other participant.