### PR TITLE
fix: build on gcc version 12.3.0

### DIFF
--- a/core/src/utility/math_utility.tpp
+++ b/core/src/utility/math_utility.tpp
@@ -418,7 +418,7 @@ Tensor2<3,double_v_t> computeInverse(const Tensor2<3,double_v_t> &matrix, const 
   return result;
 }
 
-template<typename double_v_t=double>
+template<typename double_v_t>
 std::array<double_v_t,9> computeTransformationMatrixAndDeterminant(const std::array<VecD<3,double_v_t>,3> &jacobian, double_v_t &determinant)
 {
   // rename input values
@@ -455,7 +455,7 @@ std::array<double_v_t,9> computeTransformationMatrixAndDeterminant(const std::ar
   return result;
 }
 
-template<typename double_v_t=double>
+template<typename double_v_t>
 std::array<double_v_t,9> computeTransformationDiffusionMatrixAndDeterminant(const std::array<VecD<3,double_v_t>,3> &jacobian, const Matrix<3,3,double_v_t> &diffusionTensor, double_v_t &determinant)
 {
   // rename input values


### PR DESCRIPTION
without this fix gcc fails like this
```
scons: Building targets ...
[ 20%] Compiling core/src/control/dihu_context.cpp
Building compilation database core/build_release/compile_commands.json
[ 22%] Compiling core/src/control/multiple_instances.cpp
In file included from core/src/utility/math_utility.h:236,
                 from core/src/function_space/00_function_space_base_dim.tpp:3,
                 from core/src/function_space/00_function_space_base_dim.h:33,
                 from core/src/mesh/unstructured_deformable.h:10,
                 from core/src/mesh/type_traits.h:5,
                 from core/src/partition/mesh_partition/01_mesh_partition.h:9,
                 from core/src/partition/partition_manager.h:6,
                 from core/src/control/dihu_context.h:18,
                 from core/src/control/dihu_context.cpp:1:
core/src/utility/math_utility.tpp:421:10: error: redefinition of default argument for ‘class double_v_t’
  421 | template<typename double_v_t=double>
      |          ^~~~~~~~
core/src/utility/math_utility.h:83:10: note: original definition appeared here
   83 | template<typename double_v_t=double>
      |          ^~~~~~~~
core/src/utility/math_utility.tpp:458:10: error: redefinition of default argument for ‘class double_v_t’
  458 | template<typename double_v_t=double>
      |          ^~~~~~~~
core/src/utility/math_utility.h:88:10: note: original definition appeared here
   88 | template<typename double_v_t=double>
      |          ^~~~~~~~
In file included from core/src/utility/math_utility.h:236,
                 from core/src/function_space/00_function_space_base_dim.tpp:3,
                 from core/src/function_space/00_function_space_base_dim.h:33,
                 from core/src/mesh/unstructured_deformable.h:10,
                 from core/src/mesh/type_traits.h:5,
                 from core/src/partition/mesh_partition/01_mesh_partition.h:9,
                 from core/src/partition/partition_manager.h:6,
                 from core/src/control/dihu_context.h:18,
                 from core/src/control/multiple_instances.h:10,
                 from core/src/control/multiple_instances.cpp:1:
core/src/utility/math_utility.tpp:421:10: error: redefinition of default argument for ‘class double_v_t’
  421 | template<typename double_v_t=double>
      |          ^~~~~~~~
core/src/utility/math_utility.h:83:10: note: original definition appeared here
   83 | template<typename double_v_t=double>
      |          ^~~~~~~~
core/src/utility/math_utility.tpp:458:10: error: redefinition of default argument for ‘class double_v_t’
  458 | template<typename double_v_t=double>
      |          ^~~~~~~~
core/src/utility/math_utility.h:88:10: note: original definition appeared here
   88 | template<typename double_v_t=double>
      |          ^~~~~~~~
scons: *** [core/build_release/src/control/dihu_context.o] Error 1
scons: *** [core/build_release/src/control/multiple_instances.o] Error 1
scons: building terminated because of errors.
make: *** [Makefile:39: release_without_tests] Error 2
[1]    241244 exit 2     make release_without_tests
```