### PR TITLE
fix: `make doc` and ignore doxygen output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ dependencies
 **/mappings_between_meshes_log.txt
 **/solver_structure.txt
 **/old*
+/doc/doxygen/html
+/doc/doxygen/latex

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean all
+.PHONY: clean all doc
 
 all: debug_without_tests release
 


### PR DESCRIPTION
doc is not marked as PHONY, which means it cant be run because there is already a doc/ directory in the repo. Without PHONY this will then result in
```
make: 'doc' is up to date.
```