### PR TITLE
fix: actually have opencor optionally

### DIFF
--- a/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
+++ b/core/src/cellml/source_code_generator/00_source_code_generator_base.cpp
@@ -234,6 +234,7 @@ void CellmlSourceCodeGeneratorBase::convertFromXmlToC()
 
   LOG(DEBUG) << "useOpenCor=" << useOpenCor << ", cFilename: " << cFilename << ", sourceFilename_: " << sourceFilename_;
 
+#ifdef HAVE_OPENCOR
   if (useOpenCor)
   {
     // do conversion on rank 0
@@ -249,6 +250,7 @@ void CellmlSourceCodeGeneratorBase::convertFromXmlToC()
       }
     }
   }
+#endif
 
   //LOG(DEBUG) << "MPI barrier, wait on all ranks until conversion is finished, n ranks: " << DihuContext::partitionManager()->rankSubsetForCollectiveOperations()->size();
 


### PR DESCRIPTION
we need this as a compile time check, we cant have this as runtime check because OPENCOR_FORMATS_DIRECTORY and OPENCOR_BINARY define values are missing so build doesnt succeed